### PR TITLE
Joel review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ figures
 output
 rt-ct
 rt-ct_threads
+.Rproj.user

--- a/R/ct-rt-utils.R
+++ b/R/ct-rt-utils.R
@@ -14,14 +14,13 @@ stan_data <- function(obs, load_vec = "p2ch1cq", overall_prob = 1,
   # define observations
   dat <- list()
   dat$n <- nrow(obs)
-  dat$t <- max(obs$time) + 1
-  dat$tt <- obs$time + 1
+  dat$t <- max(obs$time)
+  dat$tt <- obs$time
   dat$ct <- obs[["p2ch1cq"]]
   dat$dt <- dt
   
   # observations by time point
   dat$nt <- copy(obs)[, .(nobs = .N), by = time][order(time)]
-  dat$nt <- dat$nt[, time := time + 1]
   dat$nt <- merge(data.table(time = 1:dat$t), dat$nt, by = "time", all = TRUE)
   dat$nt <- dat$nt[is.na(nobs), nobs := 0]
   dat$nt <- dat$nt$nobs
@@ -34,7 +33,7 @@ stan_data <- function(obs, load_vec = "p2ch1cq", overall_prob = 1,
   dat$ct_inf_mean <- ct$mean
   dat$ct_inf_sd <- ct$sd
   dat$ut <- dat$t + dat$ctmax
-  
+
   # gaussian process parameters
   dat$M <- ceiling(dat$ut * gp_m)
   dat$L <- 2

--- a/R/ct-rt-utils.R
+++ b/R/ct-rt-utils.R
@@ -18,12 +18,6 @@ stan_data <- function(obs, load_vec = "p2ch1cq", overall_prob = 1,
   dat$tt <- obs$time
   dat$ct <- obs[["p2ch1cq"]]
   dat$dt <- dt
-  
-  # observations by time point
-  dat$nt <- copy(obs)[, .(nobs = .N), by = time][order(time)]
-  dat$nt <- merge(data.table(time = 1:dat$t), dat$nt, by = "time", all = TRUE)
-  dat$nt <- dat$nt[is.na(nobs), nobs := 0]
-  dat$nt <- dat$nt$nobs
 
   # overall probability scaling factor
   dat$overall_prob <- overall_prob

--- a/R/ct-rt-utils.R
+++ b/R/ct-rt-utils.R
@@ -1,30 +1,36 @@
 library(EpiNow2)
+library(data.table)
+
 # define required stan data
 stan_data <- function(obs, load_vec = "p2ch1cq", overall_prob = 1, 
-                      ct_mean, ct_sd, dt = 30,
+                      ct, dt = 30,
                       gt = get_generation_time(
                         disease = "SARS-CoV-2", source = "ganyani", max = 15
                         ), gp_m = 0.3, gp_ls = c(7, NA)
                       ) {
   
+  obs <- as.data.table(obs)
+
   # define observations
   dat <- list()
-  dat$N <- nrow(obs)
+  dat$n <- nrow(obs)
   dat$t <- max(obs$time) + 1
   dat$tt <- obs$time + 1
   dat$ct <- obs[["p2ch1cq"]]
   dat$dt <- dt
   
+  # observations by time point
+  dat$nt <- obs[, .(n = .N), by = time][order(time)]
+  dat$nt <- merge(data.table(time = 1:dat$t), dat$nt, by = "time", all = TRUE)
+  date$nt <- dat$nt[is.na(n), n := 0]$n
+  
   # overall probability scaling factor
   dat$overall_prob <- overall_prob
   
   # define ct parameters + unobserved time
-  if (length(ct_mean) != length(ct_sd)) {
-    stop("CT mean and standard deviation vector must be the same length")
-  }
-  dat$ctmax <- length(ct_mean)
-  dat$ct_inf_mean <- ct_mean
-  dat$ct_inf_sd <- ct_sd
+  dat$ctmax <- length(ct$mean)
+  dat$ct_inf_mean <- ct$mean
+  dat$ct_inf_sd <- ct$sd
   dat$ut <- dat$t + dat$ctmax
   
   # gaussian process parameters

--- a/R/ct-rt-utils.R
+++ b/R/ct-rt-utils.R
@@ -20,10 +20,12 @@ stan_data <- function(obs, load_vec = "p2ch1cq", overall_prob = 1,
   dat$dt <- dt
   
   # observations by time point
-  dat$nt <- obs[, .(n = .N), by = time][order(time)]
+  dat$nt <- copy(obs)[, .(nobs = .N), by = time][order(time)]
+  dat$nt <- dat$nt[, time := time + 1]
   dat$nt <- merge(data.table(time = 1:dat$t), dat$nt, by = "time", all = TRUE)
-  date$nt <- dat$nt[is.na(n), n := 0]$n
-  
+  dat$nt <- dat$nt[is.na(nobs), nobs := 0]
+  dat$nt <- dat$nt$nobs
+
   # overall probability scaling factor
   dat$overall_prob <- overall_prob
   

--- a/R/ct-rt.R
+++ b/R/ct-rt.R
@@ -29,7 +29,7 @@ ep_raw_vacc <- readRDS(here("data", "ct_covariates.rds"))
 
 # Data for stan -----------------------------------------------------------
 # subsample available data
-samples <- sample(1:nrow(ep_raw_vacc), 5000)
+samples <- sample(1:nrow(ep_raw_vacc), 1000)
 ep_raw_vacc <- ep_raw_vacc[samples, ]
 min_date <- min(ep_raw_vacc$date_specimen, na.rm = TRUE)
 
@@ -41,12 +41,11 @@ ct <- tibble(mean = c(40 - 0:4*5, 18 + 0:10*2),
 dat <- stan_data(ep_raw_vacc, 
                  load_vec = "p2ch1cq",
                  overall_prob = 1,
-                 ct_mean =  ct$mean,
-                 ct_sd =  ct$sd,
+                 ct =  ct,
                  dt = 30,
                  gt = get_generation_time(
                    disease = "SARS-CoV-2", source = "ganyani", max = 15
-                   ), gp_m = 0.3, gp_ls = c(7, NA)
+                   ), gp_m = 0.1, gp_ls = c(7, NA)
                  )
 
 # Load model --------------------------------------------------------------

--- a/R/ct-rt.R
+++ b/R/ct-rt.R
@@ -35,7 +35,7 @@ samples <- sample(1:nrow(ep_raw_vacc), 1000)
 ep_raw_vacc <- ep_raw_vacc[samples, ]
 min_date <- min(ep_raw_vacc$date_specimen, na.rm = TRUE)
 
-# define CT post infection (loosely inspired Hay et al)
+# define CT post infection (loosely inspired by Hay et al)
 ct <- tibble(mean = c(40 - 0:4*5, 18 + 0:10*2),
              sd = c(rep(1, 5), rep(2, 11)))
 
@@ -61,7 +61,7 @@ fit <- mod$sample(data = dat, parallel_chains = cores,
 fit$cmdstan_diagnose()
 
 # summarise fit
-fit$summary()
+fit$cmdstan_summary()
 
 # Plot variables over time ------------------------------------------------
 plot_trend(fit, "prob_inf", date_start = min_date - dat$ctmax) +

--- a/R/ct-rt.R
+++ b/R/ct-rt.R
@@ -26,10 +26,12 @@ threads <- 4
 # Load data ---------------------------------------------------------------
 # must contain, viral load or proxy, time, date
 ep_raw_vacc <- readRDS(here("data", "ct_covariates.rds"))
+# make time indexed from 1
+ep_raw_vacc$time <- ep_raw_vacc$time + 1
 
 # Data for stan -----------------------------------------------------------
 # subsample available data
-samples <- sample(1:nrow(ep_raw_vacc), 5000)
+samples <- sample(1:nrow(ep_raw_vacc), 1000)
 ep_raw_vacc <- ep_raw_vacc[samples, ]
 min_date <- min(ep_raw_vacc$date_specimen, na.rm = TRUE)
 

--- a/R/ct-rt.R
+++ b/R/ct-rt.R
@@ -29,7 +29,7 @@ ep_raw_vacc <- readRDS(here("data", "ct_covariates.rds"))
 
 # Data for stan -----------------------------------------------------------
 # subsample available data
-samples <- sample(1:nrow(ep_raw_vacc), 1000)
+samples <- sample(1:nrow(ep_raw_vacc), 5000)
 ep_raw_vacc <- ep_raw_vacc[samples, ]
 min_date <- min(ep_raw_vacc$date_specimen, na.rm = TRUE)
 

--- a/ctdist.Rproj
+++ b/ctdist.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/stan/functions/ct.stan
+++ b/stan/functions/ct.stan
@@ -10,7 +10,7 @@ vector ct_threshold_prob(real dt, vector ct_inf_mean, vector ct_inf_sd) {
 vector rel_threshold_prob(vector[] lrit, int t) {
   vector[t] ldtpt;
   for (i in 1:t) {
-    ldtpt[i] = -log_sum_exp(lrit[i]);
+    ldtpt[i] = log_sum_exp(lrit[i]);
   }
   return(ldtpt);
 }

--- a/stan/functions/ct.stan
+++ b/stan/functions/ct.stan
@@ -7,10 +7,10 @@ vector ct_threshold_prob(real dt, vector ct_inf_mean, vector ct_inf_sd) {
   }
   return(ldtp);
 }
-vector rel_threshold_prob(vector ldtp, vector[] lrit, int t) {
+vector rel_threshold_prob(vector[] lrit, int t) {
   vector[t] ldtpt;
   for (i in 1:t) {
-    ldtpt[i] = log_sum_exp(lrit[i] + ldtp);
+    ldtpt[i] = -log_sum_exp(lrit[i]);
   }
   return(ldtpt);
 }
@@ -27,16 +27,16 @@ vector[] ct_log_dens(real[] ct, vector ct_inf_mean, vector ct_inf_sd) {
   return(ctlgd);
 }
 // relative infection probability for each reference time look up
-vector[] rel_inf_prob(vector inf, int ctmax, int t) {
+vector[] rel_inf_prob(vector prob_inf, vector ldtp, int ctmax, int t) {
   int p;
   vector[ctmax] lrit[t - ctmax];
   for (i in (ctmax + 1):t) {
     p = i - ctmax;
     lrit[p] = rep_vector(1e-8, ctmax);
     for (j in 1:ctmax) {
-      lrit[p][j] += inf[i - j];
+      lrit[p][j] += prob_inf[i - j];
     } 
-   lrit[p] = log(lrit[p]);
+   lrit[p] = log(lrit[p]) + ldtp;
   }
   return(lrit);
 }
@@ -47,7 +47,7 @@ real ct_loglik(real[] ct, int start, int end, int[] tt, vector[] lrit,
   int t;
   for (n in start:end) {
     t = tt[n];
-    tar += log_sum_exp(lrit[t] + ctlgd[n]);// - ldtpt[t];
+    tar += log_sum_exp(lrit[t] + ctlgd[n]) - ldtpt[t];
   }
   return(tar);
 }

--- a/stan/functions/ct.stan
+++ b/stan/functions/ct.stan
@@ -7,10 +7,10 @@ vector ct_threshold_prob(real dt, vector ct_inf_mean, vector ct_inf_sd) {
   }
   return(ldtp);
 }
-vector rel_threshold_prob(vector ldtp, vector[] lrit, int t, int ctmax) {
+vector rel_threshold_prob(vector ldtp, vector[] lrit, int[] nt, int t) {
   vector[t] ldtpt;
   for (i in 1:t) {
-    ldtpt[i] = log_sum_exp(lrit[i] + ldtp);
+    ldtpt[i] = log_sum_exp(lrit[i] + ldtp) * nt[i];
   }
   return(ldtpt);
 }
@@ -42,7 +42,7 @@ vector[] rel_inf_prob(vector inf, int ctmax, int t) {
 }
 // log likelihood across CT observations
 real ct_loglik(real[] ct, int start, int end, int[] tt, vector[] lrit,
-vector[] ctlgd, vector ldtpt, int ctmax) {
+               vector[] ctlgd, vector ldtpt) {
   real tar = 0;
   int t;
   for (n in start:end) {

--- a/stan/functions/ct.stan
+++ b/stan/functions/ct.stan
@@ -47,7 +47,7 @@ real ct_loglik(real[] ct, int start, int end, int[] tt, vector[] lrit,
   int t;
   for (n in start:end) {
     t = tt[n];
-    tar += log_sum_exp(lrit[t] + ctlgd[n]) - ldtpt[t];
+    tar += log_sum_exp(lrit[t] + ctlgd[n]);// - ldtpt[t];
   }
   return(tar);
 }

--- a/stan/functions/ct.stan
+++ b/stan/functions/ct.stan
@@ -7,10 +7,10 @@ vector ct_threshold_prob(real dt, vector ct_inf_mean, vector ct_inf_sd) {
   }
   return(ldtp);
 }
-vector rel_threshold_prob(vector ldtp, vector[] lrit, int[] nt, int t) {
+vector rel_threshold_prob(vector ldtp, vector[] lrit, int t) {
   vector[t] ldtpt;
   for (i in 1:t) {
-    ldtpt[i] = log_sum_exp(lrit[i] + ldtp) * nt[i];
+    ldtpt[i] = log_sum_exp(lrit[i] + ldtp);
   }
   return(ldtpt);
 }

--- a/stan/rt-ct.stan
+++ b/stan/rt-ct.stan
@@ -11,7 +11,6 @@ data {
   int ut; // time considered + ctmax
   int tt[n]; // time each sample taken
   real ct[n]; // count with ct value 
-  int nt[t]; // number of ct samples at each observation time
   real dt; // detection threshold
   real overall_prob; // overall probability of infection
   int ctmax; // maximum number of days post infection considered for ct values
@@ -62,7 +61,7 @@ model {
   // relative log probability of infection for each t
   lrit = rel_inf_prob(prob_inf, ctmax, ut);
   // log prob of detection for each t
-  ldtpt = rel_threshold_prob(ldtp, lrit, nt, t);
+  ldtpt = rel_threshold_prob(ldtp, lrit, t);
   // update likelihood (in parallel)
   //target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
   // if using rstan/no reduce_sum comment out above and use below instead

--- a/stan/rt-ct.stan
+++ b/stan/rt-ct.stan
@@ -59,13 +59,13 @@ model {
   alpha ~ normal(0, 1);
   eta ~ std_normal();
   // relative log probability of infection for each t
-  lrit = rel_inf_prob(prob_inf, ctmax, ut);
+  lrit = rel_inf_prob(prob_inf, ldtp, ctmax, ut);
   // log prob of detection for each t
-  ldtpt = rel_threshold_prob(ldtp, lrit, t);
+  ldtpt = rel_threshold_prob(lrit, t);
   // update likelihood (in parallel)
-  //target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
+  target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
   // if using rstan/no reduce_sum comment out above and use below instead
-  target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
+  //target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
 }
 
 generated quantities {

--- a/stan/rt-ct.stan
+++ b/stan/rt-ct.stan
@@ -64,9 +64,9 @@ model {
   // log prob of detection for each t
   ldtpt = rel_threshold_prob(ldtp, lrit, nt, t);
   // update likelihood (in parallel)
-  target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
+  //target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
   // if using rstan/no reduce_sum comment out above and use below instead
-  //target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
+  target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
 }
 
 generated quantities {

--- a/stan/rt-ct.stan
+++ b/stan/rt-ct.stan
@@ -64,9 +64,9 @@ model {
   // log prob of detection for each t
   ldtpt = rel_threshold_prob(ldtp, lrit, nt, t);
   // update likelihood (in parallel)
-  //target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
+  target += reduce_sum(ct_loglik, ct, 1, tt, lrit, ctlgd, ldtpt);
   // if using rstan/no reduce_sum comment out above and use below instead
-  target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
+  //target += ct_loglik(ct, 1, n, tt, lrit, ctlgd, ldtpt);
 }
 
 generated quantities {


### PR DESCRIPTION
Confirmed Sam's suspicion that there should be an extra probability of detection.
Essentially `p_a(X)` in the likelihood is equal to `P(ct is X) * P(X is detected)`

So I have modified `ct_log_dens` to account for this so that our log normal density for each observation and day since infection now includes `P(X detected) = phi(X)`.

I also include `phi` in the denominator used in `ct_loglik` (denominator is `ldtdt` at each time step) by including it straight in `rel_threshold_prob`.

The resulting changes in Rt make it more similar to Rt estimates from other sources. Not sure what is going on in late December. 
![image](https://user-images.githubusercontent.com/10957016/110139499-00315c00-7dcb-11eb-8735-a2f140354586.png)
